### PR TITLE
Changed comment WebServer.h to HTTPServer.h to match the file name.

### DIFF
--- a/pic32/libraries/HTTPServer/HTTPServer.h
+++ b/pic32/libraries/HTTPServer/HTTPServer.h
@@ -1,6 +1,6 @@
 /************************************************************************/
 /*                                                                      */
-/*    WebServer.h                                                       */
+/*    HTTPServer.h                                                       */
 /*                                                                      */
 /*    A chipKIT WiFi Server implementation                              */
 /*    Designed to look for and parse /GET commands and automatically    */


### PR DESCRIPTION
I'm guessing that HTTPServer.h was at one time called WebServer.h and the title comment at the top of the file never got updated. To avoid confusion I'm proposing we fix this.