### PR TITLE
Remove / to fix links to JS files

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -7,8 +7,8 @@
 	{% include bootstrap_head.html %}
 	
 	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
-    <script src="/js/w3data.js"></script>
-    <script type="text/javascript" src="/js/jquery.ntm.js"></script>
+    <script src="js/w3data.js"></script>
+    <script type="text/javascript" src="js/jquery.ntm.js"></script>
 	<link href="assets/highlighter-monokai.css" rel="stylesheet" type="text/css">
 	<link href="assets/toctheme/css/toctheme.css" rel="stylesheet" type="text/css">
 	<link href="assets/style.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Missed a slash so the live sites colapsable TOC was still broke. This should fix it.